### PR TITLE
Added instructions for deploying to Heroku.

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -24,3 +24,10 @@ You can setup an app in the `Google App Engine <https://developers.google.com/ap
 by changing the ``application`` key in app.yaml to your application name. 
 For using it you just need to do the API calls to :samp:`http://{your-app-name}.appspot.com`.
 It needs some external python modules in :samp:`lib`, you can download them by running :command:`./devscripts/setup-gae.sh`
+
+Heroku
+******
+You can also run the server on `Heroku <https://heroku.com>`_ by adding ``gunicorn`` to ``requirements.txt``
+and creating a ``Procfile`` with ``web: gunicorn --pythonpath youtube_dl_server app:app -w 4 --log-file -``.
+
+Commit, push to Heroku and you can make your API calls to :samp:`https://{app-name}.herokuapp.com/`.


### PR DESCRIPTION
Some instructions for deploying to Heroku, an alternative to GAE.