### PR TITLE
Version

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -90,6 +90,34 @@ API methods
 
         }
 
+
+.. http:get:: /api/version
+
+    Get the youtube-dl and youtube-dl-api-server version
+
+    :resheader Content-Type: ``application/json``
+    :resheader Access-Control-Allow-Origin: ``*``
+    :status 200: On success
+
+    |ex-request|
+
+    .. sourcecode:: http
+
+        GET /api/version HTTP/1.1
+
+    |ex-response|
+
+    .. sourcecode:: http
+
+        HTTP/1.1 200 OK
+        Access-Control-Allow-Origin: *
+        Content-Type: application/json
+
+        {
+            "youtube-dl": "2016.04.19",
+            "youtube-dl-api-server": "0.2.1"
+        }
+
 Test server
 -----------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -115,7 +115,7 @@ API methods
 
         {
             "youtube-dl": "2016.04.19",
-            "youtube-dl-api-server": "0.2.1"
+            "youtube-dl-api-server": "0.2"
         }
 
 Test server

--- a/docs/example_info.rst.inc
+++ b/docs/example_info.rst.inc
@@ -49,5 +49,4 @@
         "webpage_url_basename": "dan_dennett_on_our_consciousness.html"
       },
       "url": "http://www.ted.com/talks/dan_dennett_on_our_consciousness.html",
-      "youtube-dl.version": "2014.03.12"
     }

--- a/docs/example_info_flatten.rst.inc
+++ b/docs/example_info_flatten.rst.inc
@@ -51,5 +51,4 @@
           "webpage_url_basename": "dan_dennett_on_our_consciousness.html"
         }
       ],
-      "youtube-dl.version": "2014.03.12"
     }

--- a/youtube_dl_server/app.py
+++ b/youtube_dl_server/app.py
@@ -6,6 +6,7 @@ import sys
 from flask import Flask, jsonify, request
 import youtube_dl
 from youtube_dl.version import __version__ as youtube_dl_version
+from .version import __version__ as youtube_dl_api_server_version
 
 
 if not hasattr(sys.stderr, 'isatty'):
@@ -134,7 +135,6 @@ def info():
         result = flatten_result(result)
         key = 'videos'
     result = {
-        'youtube-dl.version': youtube_dl_version,
         'url': url,
         key: result,
     }
@@ -149,3 +149,13 @@ def list_extractors():
         'working': ie.working(),
     } for ie in youtube_dl.gen_extractors()]
     return jsonify(extractors=ie_list)
+
+
+@route_api('version')
+@set_access_control
+def version():
+    result = {
+        'youtube-dl': youtube_dl_version,
+        'youtube-dl-api-server': youtube_dl_api_server_version,
+    }
+    return jsonify(result)


### PR DESCRIPTION
Hi again, I've made some changes:

- Add /api/version to know which versions of youtube-dl and youtube-dl-api-server are running
- Remove youtube-dl version from /api/info It isn't longer necessary
- Update documentation