### PR TITLE
gcloud_app.yaml added to support the new gcloud tooling

### DIFF
--- a/gcloud_app.yaml
+++ b/gcloud_app.yaml
@@ -1,0 +1,39 @@
+runtime: python27
+api_version: 1
+threadsafe: no
+
+handlers:
+- url: /api/.*
+  script: mainGAE.app
+  secure: optional
+
+- url: /robots.txt
+  static_files: robots.txt
+  upload: robots.txt
+
+- url: /.*
+  static_files: index.html
+  upload: index.html
+
+libraries:
+- name: ssl
+  version: latest
+- name: jinja2
+  version: "2.6"
+
+
+skip_files:
+# Default values from https://developers.google.com/appengine/docs/python/config/appconfig#Python_app_yaml_Skipping_files
+- ^(.*/)?#.*#$
+- ^(.*/)?.*~$
+- ^(.*/)?.*\.py[co]$
+- ^(.*/)?.*/RCS/.*$
+- ^(.*/)?\..*$
+# Custom values
+- ^VENV.*$
+- ^.*\.egg.*$
+- ^gae/VENV$
+- ^dist/.*$
+- ^docs/.*$
+- ^test/.*$
+- ^devscripts/.*$


### PR DESCRIPTION
the new gcloud tooling doesn't allow application and version tags in app.yaml instead set project id using
`gcloud config set project [PROJECT_ID]` and versions are handled automatically but can be overridden using `--version` flag
Usage: `gcloud app deploy gcloud_app.yaml`