### PR TITLE
Explicitly disable threading when running the Flask app.

### DIFF
--- a/youtube_dl_server/server.py
+++ b/youtube_dl_server/server.py
@@ -45,4 +45,4 @@ def main():
         print(__version__)
         exit(0)
 
-    app.run(args.host, args.port, processes=args.number_processes)
+    app.run(args.host, args.port, processes=args.number_processes, threaded=False)


### PR DESCRIPTION
Flask 1.0+ enables threading by default. Disable it to make sure the
latest version of flask works.

WIthout this fix, I get the error:

```
root@localhost:~$ /opt/youtube-dl/bin/youtube-dl-server
 * Serving Flask app "youtube_dl_server.app" (lazy loading)
 * Environment: production
   WARNING: Do not use the development server in a production environment.
   Use a production WSGI server instead.
 * Debug mode: off
Traceback (most recent call last):
  File "/opt/youtube-dl/bin/youtube-dl-server", line 11, in <module>
    sys.exit(main())
  File "/opt/youtube-dl/local/lib/python2.7/site-packages/youtube_dl_server/server.py", line 48, in main
    app.run(args.host, args.port, processes=args.number_processes)
  File "/opt/youtube-dl/local/lib/python2.7/site-packages/flask/app.py", line 943, in run
    run_simple(host, port, self, **options)
  File "/opt/youtube-dl/local/lib/python2.7/site-packages/werkzeug/serving.py", line 814, in run_simple
    inner()
  File "/opt/youtube-dl/local/lib/python2.7/site-packages/werkzeug/serving.py", line 774, in inner
    fd=fd)
  File "/opt/youtube-dl/local/lib/python2.7/site-packages/werkzeug/serving.py", line 656, in make_server
    raise ValueError("cannot have a multithreaded and "
ValueError: cannot have a multithreaded and multi process server.
```