### PR TITLE
Add dockefile and docker compose file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM frolvlad/alpine-python3:latest
+
+RUN apk add --no-cache git
+
+RUN git clone https://github.com/jaimeMF/youtube-dl-api-server && \
+    cd youtube-dl-api-server && \
+    pip install -e .
+
+EXPOSE 9191
+
+ENTRYPOINT [ "youtube-dl-server", "--number-processes", "1", "--host", "0.0.0.0"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3'
+services:
+  ytube_dl:
+    build: .
+    ports:
+      - "9191:9191"


### PR DESCRIPTION
- Adds a Dockerfile to easily compile and run the server on any platform.
- Adds docker-compose to make starting the server as easy as: `docker-compose up -d`

You can also add a reference to docker hub to make starting the server even more convenient

Reference issues: #66