### PR TITLE
Replace Youtube-DL To YT-DLP

### DIFF
--- a/mainGAE.py
+++ b/mainGAE.py
@@ -3,9 +3,9 @@ import os
 sys.path.append(os.path.join(os.path.dirname(__file__), 'gae/lib'))
 
 # Monkeypatch some youtube_dl functions that use features not available in GAE
-import youtube_dl
+import yt_dlp
 # Modifying youtube_dl.utils.get_cachedir doesn't work
-youtube_dl.extractor.youtube.get_cachedir = lambda *args, **kargs: None
+yt_dlp.extractor.youtube.get_cachedir = lambda *args, **kargs: None
 
 
 from youtube_dl_server.app import app  # noqa: app is used by GAE

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-youtube_dl >= 2014.03.12
+yt-dlp >= 2022.08.14
 flask
 gunicorn


### PR DESCRIPTION
Hi I Have Changed Youtube-dl to yt-dlp because due to inactivity yt-dlp is now running with active members so i have changed with it check if i have changed well then update or edit it thanks